### PR TITLE
Fix/event heatmap tap reliability

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,11 +1,11 @@
 name: Deploy Backend
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'backend/**'
-      - 'docker-compose.prod.yml'
+  # push:
+  #   branches: [main]
+  #   paths:
+  #     - 'backend/**'
+  #     - 'docker-compose.prod.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,10 +1,10 @@
 name: Deploy Frontend
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "frontend/**"
+  # push:
+  #   branches: [main]
+  #   paths:
+  #     - "frontend/**"
   workflow_dispatch:
 
 jobs:

--- a/frontend/src/components/ui/pages/event/HeatmapTabs.tsx
+++ b/frontend/src/components/ui/pages/event/HeatmapTabs.tsx
@@ -163,9 +163,14 @@ export const HeatmapTabs = ({
 							onPointerDown={e => {
 								if (!canDrag) return;
 								const el = document.elementFromPoint(e.clientX, e.clientY);
-								if (!el?.closest("[data-slot]")) return;
+								const slot = el?.closest("[data-slot]")?.getAttribute("data-slot");
+								if (!slot) return;
 								isDragging.current = true;
 								visitedSlots.current.clear();
+								visitedSlots.current.add(slot);
+								setSelectedSlots(prev =>
+									prev.includes(slot) ? prev.filter(s => s !== slot) : [...prev, slot],
+								);
 								(e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
 							}}
 							onPointerMove={e => {
@@ -265,13 +270,6 @@ export const HeatmapTabs = ({
 													data-slot={realSlot}
 													className="relative w-12 h-12 shrink-0 m-0.5 overflow-hidden rounded-xl"
 													disabled={!me}
-													onClick={() =>
-														setSelectedSlots(prev =>
-															prev.includes(realSlot)
-																? prev.filter(s => s !== realSlot)
-																: [...prev, realSlot],
-														)
-													}
 												>
 													<div className="absolute inset-0 rounded-xl bg-paint" />
 													<motion.span


### PR DESCRIPTION
- Root cause: `setPointerCapture` on the parent container prevented the cell's `onClick` from firing, so toggles only happened through accidental `pointermove` events. With a tiny pointer jitter both `pointermove` and `click` fired, cancelling each other out.
- Fix: toggle the initial slot directly in `onPointerDown`, track it in `visitedSlots` so drag doesn't re-toggle, and remove the dead `onClick` on the cell button.


Part of #63 